### PR TITLE
Remove query and bodyParser middlewares

### DIFF
--- a/server-info.js
+++ b/server-info.js
@@ -25,9 +25,7 @@ var Future = Npm.require('fibers/future');
 // allow the user to configure the package
 Meteor.startup(function() {
   connectHandlers
-    .use(connect.query())
-    .use(connect.bodyParser())
-    .use(ServerInfo.settings.path, 
+    .use(ServerInfo.settings.path,
       connect.basicAuth(ServerInfo.settings.user, ServerInfo.settings.password))
     .use(ServerInfo.settings.path, function(req, res, next) {
       Fiber(function () {


### PR DESCRIPTION
Neither one of these are used by the package and they cause issues with
other routes defined in Meteor, if those routes expect, for example, JSON
payload in the request since internally connect doesn't use Fibers and the
callbacks are not bound to meteor.